### PR TITLE
gvisor: endpoint can writev up to rawfile.MaxIovs

### DIFF
--- a/gvisor/endpoint.go
+++ b/gvisor/endpoint.go
@@ -91,7 +91,7 @@ func (e *rwEndpoint) WritePackets(pkts stack.PacketBufferList) (int, tcpip.Error
 	for pkt := pkts.Front(); pkt != nil; pkt = pkt.Next() {
 		views := pkt.Views()
 		for _, v := range views {
-			batch = rawfile.AppendIovecFromBytes(batch, v, len(views))
+			batch = rawfile.AppendIovecFromBytes(batch, v, rawfile.MaxIovs)
 		}
 	}
 	err := rawfile.NonBlockingWriteIovec(e.fd, batch)


### PR DESCRIPTION
nb: I am yet to test this change with SagerNet but a similar change for [celzero/firestack](https://github.com/celzero/firestack) used by RethinkDNS fixed issues with frequent dropped/reset conns.