### PR TITLE
Quick close the gvisor stack+endpoint

### DIFF
--- a/gvisor/gvisor.go
+++ b/gvisor/gvisor.go
@@ -31,6 +31,7 @@ type GVisor struct {
 }
 
 func (t *GVisor) Close() error {
+	t.Endpoint.Attach(nil)
 	t.Stack.Close()
 	if t.PcapFile != nil {
 		_ = t.PcapFile.Close()


### PR DESCRIPTION
Without `endpoint.Attach` the tun `fd` takes forever to close, at times.